### PR TITLE
codemirror support double quotes `items.getItem("`

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-javascript.ts
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-javascript.ts
@@ -215,7 +215,7 @@ function hintOpenhabJs (context: CompletionContext) {
 }
 
 function hintJsItems (context: any) {
-  if (context.matchBefore(/(\s|^)items\.(getItem\(')?[\w-]*/)) {
+  if (context.matchBefore(/(\s|^)items\.(getItem\(['"])?[\w]*/)) {
     return hintUtils.hintItems(context)
   }
 }


### PR DESCRIPTION
A small improvement. Some people use double quoted strings in their js rules.